### PR TITLE
Fix for TLS v1.2 issue

### DIFF
--- a/src/GitHubReleaseManager.psm1
+++ b/src/GitHubReleaseManager.psm1
@@ -14,5 +14,5 @@ foreach($Function in $Public) {
     }
 
 }
-
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 # GitHub requires TLS version 1.2
 Export-ModuleMember -Function $($Public | Select-Object -ExpandProperty BaseName) -Verbose:$VerbosePreference


### PR DESCRIPTION
As GitHub requires TLS of version 1.2
![image](https://user-images.githubusercontent.com/14203428/42466060-20ac7e7a-83ae-11e8-86bc-2454a6cd6f53.png)
it is necessary to switch this on (as discussed here: https://stackoverflow.com/questions/41618766/powershell-invoke-webrequest-fails-with-ssl-tls-secure-channel). 

I added it to module loading so it is performed only once and applies to all requests.

One drawback is that this option is affecting whole session. Not sure if that is too much of a problem. It is not for me :)